### PR TITLE
Change Field Name in FunctionAbiEntryType

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -178,9 +178,9 @@ pub enum FunctionAbiEntryType {
     Constructor,
     #[serde(rename = "l1_handler")]
     L1Handler,
-    #[serde(rename = "regular")]
+    #[serde(rename = "function")]
     #[default]
-    Regular,
+    Function,
 }
 
 /// A function abi entry.


### PR DESCRIPTION
Change Type in Abi to match the one returned by starknet-compile 